### PR TITLE
Add body-parser to persistence/package.json

### DIFF
--- a/persistence/package.json
+++ b/persistence/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "express": "^4.10.6",
     "mocha": "^2.1.0",
-    "redis": "^0.12.1"
+    "redis": "^0.12.1",
+    "body-parser": "*"
   }
 }


### PR DESCRIPTION
Per README, could not start with `node index.js`
due to undefined dep.
